### PR TITLE
Workaround (not fix) for scaling issues

### DIFF
--- a/custom_components/sunspec/manifest.json
+++ b/custom_components/sunspec/manifest.json
@@ -8,5 +8,5 @@
   "config_flow": true,
   "codeowners": ["@cjne"],
   "iot_class": "local_polling",
-  "requirements": ["pysunspec2==1.0.5"]
+  "requirements": ["git+https://github.com/thecem/pysunspec2@master#pysunspec2==1.0.5"]
 }


### PR DESCRIPTION
This PR utilises the fork of pysunspec2 from thecem, whilst we await the upstream to address the scaling issue in pysunspec2.

I am currently manually applying this workaround with every upgrade of ha-sunspec.

Once addressed upstream it should be reversed to again utilise upstream pysunspec2.

Addresses #40 & #14