### PR TITLE
Return None if value for enum sensor was not found in enum states

### DIFF
--- a/custom_components/sunspec/sensor.py
+++ b/custom_components/sunspec/sensor.py
@@ -220,6 +220,8 @@ class SunSpecSensor(SunSpecEntity, SensorEntity):
                 symbol = list(filter(lambda s: s["value"] == val, symbols))
                 if len(symbol) == 1:
                     return symbol[0]["name"][:255]
+                else:
+                    return None
             else:
                 symbols = list(
                     filter(lambda s: (val >> int(s["value"])) & 1 == 1, symbols)


### PR DESCRIPTION
Hotfixes https://github.com/CJNE/ha-sunspec/issues/187

With my limited understanding of HA and SunSpec, I understood that the error is raised because the value '0' cannot be found in the discovered enum states. I failed to figure out why the value 0 was returned when reading the sensor and 0 not being mapped to an enum state during discovery.
I was able however to keep the integration from crashing with the fix in this PR. If the value cannot be mapped to an enum state we return `None`. This sets the sensor state to `Unknown` in HA.

@CJNE Let me know if I need to change anything here to get it into upstream.