### PR TITLE
Fix depcreated POWER_VOLT_AMPERE_REACTIVE

### DIFF
--- a/custom_components/sunspec/sensor.py
+++ b/custom_components/sunspec/sensor.py
@@ -8,7 +8,6 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import DEGREE
 from homeassistant.const import PERCENTAGE
-from homeassistant.const import POWER_VOLT_AMPERE_REACTIVE
 from homeassistant.const import UnitOfApparentPower
 from homeassistant.const import UnitOfDataRate
 from homeassistant.const import UnitOfElectricCurrent
@@ -19,6 +18,7 @@ from homeassistant.const import UnitOfIrradiance
 from homeassistant.const import UnitOfLength
 from homeassistant.const import UnitOfPower
 from homeassistant.const import UnitOfPressure
+from homeassistant.const import UnitOfReactivePower
 from homeassistant.const import UnitOfSpeed
 from homeassistant.const import UnitOfTemperature
 from homeassistant.const import UnitOfTime
@@ -46,7 +46,7 @@ HA_META = {
     "Mbps": [UnitOfDataRate.MEGABITS_PER_SECOND, ICON_DEFAULT, None],
     "V": [UnitOfElectricPotential.VOLT, ICON_VOLT, SensorDeviceClass.VOLTAGE],
     "VA": [UnitOfApparentPower.VOLT_AMPERE, ICON_POWER, None],
-    "VAr": [POWER_VOLT_AMPERE_REACTIVE, ICON_POWER, None],
+    "VAr": [UnitOfReactivePower.VOLT_AMPERE_REACTIVE, ICON_POWER, None],
     "W": [UnitOfPower.WATT, ICON_POWER, SensorDeviceClass.POWER],
     "W/m2": [UnitOfIrradiance.WATTS_PER_SQUARE_METER, ICON_DEFAULT, None],
     "Wh": [UnitOfEnergy.WATT_HOUR, ICON_ENERGY, SensorDeviceClass.ENERGY],


### PR DESCRIPTION
Replace the deprecated constant reported in #294 with their corresponding enum.

Changing `"VAr": [POWER_VOLT_AMPERE_REACTIVE, ICON_POWER, None], to "VAr": [UnitOfReactivePower.VOLT_AMPERE_REACTIVE, ICON_POWER, None],`