### PR TITLE
Fix warning

### DIFF
--- a/custom_components/sunspec/config_flow.py
+++ b/custom_components/sunspec/config_flow.py
@@ -3,7 +3,7 @@
 import logging
 
 from homeassistant import config_entries
-from homeassistant.core import callback
+from homeassistant.core_config import callback
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 


### PR DESCRIPTION
Logger: homeassistant.core
Source: helpers/deprecation.py:222
First occurred: 20:56:39 (1 occurrences)
Last logged: 20:56:39

Config was used from sunspec, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead, please report it to the author of the 'sunspec' custom integration