### PR TITLE
Filter implausible inverter readings via configurable peak AC power

### DIFF
--- a/custom_components/sunspec/config_flow.py
+++ b/custom_components/sunspec/config_flow.py
@@ -13,6 +13,7 @@ from .api import ConnectionTimeoutError
 from .api import SunSpecApiClient
 from .const import CONF_ENABLED_MODELS
 from .const import CONF_HOST
+from .const import CONF_MAX_AC_POWER_KW
 from .const import CONF_PORT
 from .const import CONF_PREFIX
 from .const import CONF_SCAN_INTERVAL
@@ -21,6 +22,19 @@ from .const import DEFAULT_MODELS
 from .const import DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+def _optional_positive_float(value):
+    """Coerce empty values to None and validate positive floats otherwise."""
+    if value is None or value == "":
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as err:
+        raise vol.Invalid("must be a number") from err
+    if result <= 0:
+        raise vol.Invalid("must be greater than zero")
+    return result
 
 
 def set_connection_error(errors, host, port, unit_id, err):
@@ -235,6 +249,7 @@ class SunSpecOptionsFlowHandler(config_entries.OptionsFlow):
         scan_interval = self.config_entry.options.get(
             CONF_SCAN_INTERVAL, self.config_entry.data.get(CONF_SCAN_INTERVAL)
         )
+        max_ac_power_kw = self.config_entry.options.get(CONF_MAX_AC_POWER_KW)
         try:
             models = set(await self.coordinator.api.async_get_models(self.settings))
             model_filter = {model for model in sorted(models)}
@@ -245,18 +260,26 @@ class SunSpecOptionsFlowHandler(config_entries.OptionsFlow):
 
             default_models = {model for model in default_models if model in models}
 
+            schema = {
+                vol.Optional(CONF_PREFIX, default=prefix): str,
+                vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval): int,
+                vol.Optional(
+                    CONF_ENABLED_MODELS,
+                    default=default_models,
+                ): cv.multi_select(model_filter),
+            }
+            # Use suggested_value (not default) so the field can stay empty.
+            # An empty value disables the corresponding plausibility filter.
+            schema[
+                vol.Optional(
+                    CONF_MAX_AC_POWER_KW,
+                    description={"suggested_value": max_ac_power_kw},
+                )
+            ] = _optional_positive_float
+
             return self.async_show_form(
                 step_id="model_options",
-                data_schema=vol.Schema(
-                    {
-                        vol.Optional(CONF_PREFIX, default=prefix): str,
-                        vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval): int,
-                        vol.Optional(
-                            CONF_ENABLED_MODELS,
-                            default=default_models,
-                        ): cv.multi_select(model_filter),
-                    }
-                ),
+                data_schema=vol.Schema(schema),
             )
         except Exception as e:
             set_connection_error(

--- a/custom_components/sunspec/const.py
+++ b/custom_components/sunspec/const.py
@@ -30,6 +30,17 @@ CONF_SLAVE_ID = "slave_id"  # Deprecated, use CONF_UNIT_ID
 CONF_PREFIX = "prefix"
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_ENABLED_MODELS = "models_enabled"
+# Plausibility limit used to drop unrealistic values reported by inverters
+# at dawn/dusk (e.g. MW or TWh spikes). Optional - leaving the option empty
+# disables the filter. The value is used in two ways:
+#   * Power sensors are dropped if they exceed this value (in kW).
+#   * Energy sensors are dropped when the delta to the previous value would
+#     imply an instantaneous power above this value, with a safety factor.
+CONF_MAX_AC_POWER_KW = "max_ac_power_kw"
+# Safety factor applied when deriving the maximum plausible energy delta from
+# the configured peak power. Generous on purpose - we only want to catch the
+# really obvious garbage values (MW/TWh spikes).
+ENERGY_DELTA_SAFETY_FACTOR = 2.0
 
 DEFAULT_MODELS = set(
     [

--- a/custom_components/sunspec/sensor.py
+++ b/custom_components/sunspec/sensor.py
@@ -24,8 +24,11 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.const import UnitOfTime
 
 from . import get_sunspec_unique_id
+from .const import CONF_MAX_AC_POWER_KW
 from .const import CONF_PREFIX
+from .const import CONF_SCAN_INTERVAL
 from .const import DOMAIN
+from .const import ENERGY_DELTA_SAFETY_FACTOR
 from .entity import SunSpecEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -38,6 +41,43 @@ ICON_POWER = "mdi:solar-power"
 ICON_FREQ = "mdi:sine-wave"
 ICON_ENERGY = "mdi:solar-panel"
 ICON_TEMP = "mdi:thermometer"
+
+_POWER_UNITS = (
+    UnitOfPower.WATT,
+    UnitOfApparentPower.VOLT_AMPERE,
+    UnitOfReactivePower.VOLT_AMPERE_REACTIVE,
+)
+
+
+def _power_limit_in_native_unit(unit, max_power_kw):
+    """Convert the configured peak power (kW) to the sensor's native unit.
+
+    All sunspec power-like units (W, VA, VAr) are 1:1 with watts in HA, so the
+    same conversion applies. Returns None if the sensor is not power-like.
+    """
+    if max_power_kw is None or unit not in _POWER_UNITS:
+        return None
+    return max_power_kw * 1000.0
+
+
+def _energy_delta_limit_in_native_unit(unit, max_power_kw, scan_interval_seconds):
+    """Compute the maximum plausible energy delta between two consecutive reads.
+
+    Derived from the configured peak power and the scan interval, with a safety
+    factor (see ENERGY_DELTA_SAFETY_FACTOR). Returns None if the sensor is not
+    a known energy unit or no peak power is configured.
+    """
+    if max_power_kw is None or scan_interval_seconds is None:
+        return None
+    max_delta_kwh = (
+        max_power_kw * (scan_interval_seconds / 3600.0) * ENERGY_DELTA_SAFETY_FACTOR
+    )
+    if unit == UnitOfEnergy.WATT_HOUR:
+        return max_delta_kwh * 1000.0
+    if unit == UnitOfEnergy.KILO_WATT_HOUR:
+        return max_delta_kwh
+    return None
+
 
 HA_META = {
     "A": [UnitOfElectricCurrent.AMPERE, ICON_AC_AMPS, SensorDeviceClass.CURRENT],
@@ -124,6 +164,12 @@ class SunSpecSensor(SunSpecEntity, SensorEntity):
         self.lastKnown = None
         self._assumed_state = False
 
+        # Plausibility filter: if the user configured a peak AC power, drop
+        # power-like readings that exceed it. Stored in the sensor's native
+        # unit so the per-update check is a single comparison.
+        max_power_kw = config_entry.options.get(CONF_MAX_AC_POWER_KW)
+        self._max_native_value = _power_limit_in_native_unit(self.unit, max_power_kw)
+
         self._uniqe_id = get_sunspec_unique_id(
             config_entry.entry_id, self.key, self.model_id, self.model_index
         )
@@ -205,6 +251,20 @@ class SunSpecSensor(SunSpecEntity, SensorEntity):
                 "Math overflow error when retreiving calculated value for %s", self.key
             )
             return None
+        if (
+            self._max_native_value is not None
+            and isinstance(val, (int, float))
+            and val > self._max_native_value
+        ):
+            _LOGGER.warning(
+                "Dropping implausible value for %s: %s %s exceeds configured peak %s %s",
+                self.key,
+                val,
+                self.unit,
+                self._max_native_value,
+                self.unit,
+            )
+            return None
         vtype = self._meta["type"]
         if vtype in ("enum16", "bitfield32"):
             symbols = self._point_meta.get("symbols", None)
@@ -276,6 +336,17 @@ class SunSpecEnergySensor(SunSpecSensor, RestoreSensor):
         super().__init__(coordinator, config_entry, data)
         self.last_known_value = None
 
+        # Plausibility filter: derive the maximum plausible delta between two
+        # consecutive reads from the configured peak power and the scan
+        # interval. None disables the check.
+        max_power_kw = config_entry.options.get(CONF_MAX_AC_POWER_KW)
+        scan_interval = config_entry.options.get(
+            CONF_SCAN_INTERVAL, config_entry.data.get(CONF_SCAN_INTERVAL)
+        )
+        self._max_native_delta = _energy_delta_limit_in_native_unit(
+            self.unit, max_power_kw, scan_interval
+        )
+
     @property
     def native_value(self):
         val = super().native_value
@@ -283,6 +354,48 @@ class SunSpecEnergySensor(SunSpecSensor, RestoreSensor):
         if val == 0:
             _LOGGER.debug(
                 "Returning last known value instead of 0 for {self.name) to avoid resetting total_increasing counter"
+            )
+            self._assumed_state = True
+            return self.lastKnown
+        # Plausibility filter active but no baseline yet (e.g. fresh setup, or
+        # restart where the restored state was not numeric): discard this read
+        # so a potential garbage value never becomes the baseline. The next
+        # poll will have a valid lastKnown to compare against.
+        if (
+            val is not None
+            and self._max_native_delta is not None
+            and self.lastKnown is None
+            and isinstance(val, (int, float))
+        ):
+            _LOGGER.info(
+                "Establishing energy baseline for %s, discarding first read %s %s",
+                self.key,
+                val,
+                self.unit,
+            )
+            self.lastKnown = val
+            self._assumed_state = True
+            return None
+        # Delta-based plausibility check: if the increase since the last known
+        # value would imply a power above the configured peak, treat the read
+        # as garbage and fall back to the last known value (same mechanism as
+        # the val == 0 path, so total_increasing stats stay intact).
+        if (
+            val is not None
+            and self._max_native_delta is not None
+            and self.lastKnown is not None
+            and isinstance(val, (int, float))
+            and isinstance(self.lastKnown, (int, float))
+            and (val - self.lastKnown) > self._max_native_delta
+        ):
+            _LOGGER.warning(
+                "Dropping implausible energy delta for %s: %s -> %s %s exceeds max plausible delta %s %s",
+                self.key,
+                self.lastKnown,
+                val,
+                self.unit,
+                self._max_native_delta,
+                self.unit,
             )
             self._assumed_state = True
             return self.lastKnown
@@ -300,5 +413,10 @@ class SunSpecEnergySensor(SunSpecSensor, RestoreSensor):
                 f"{self.name} Got last known value from state: {state.native_value}"
             )
             self.last_known_value = state.native_value
+            # Also seed lastKnown so the val == 0 fallback and the delta-based
+            # plausibility filter work on the very first read after a restart,
+            # not only after the second poll.
+            if isinstance(state.native_value, (int, float)):
+                self.lastKnown = state.native_value
         else:
             _LOGGER.debug(f"{self.name} No previous state was found")

--- a/custom_components/sunspec/translations/en.json
+++ b/custom_components/sunspec/translations/en.json
@@ -42,13 +42,14 @@
       },
       "model_options": {
         "title": "Device Options",
-        "description": "Select what SunSpec models (data registers) you would like to create sensors for.",
+        "description": "Select what SunSpec models (data registers) you would like to create sensors for. The peak AC power is optional and used to discard unrealistic values that some inverters report at dawn or dusk (e.g. spikes in the MW or TWh range). Leave it empty to disable filtering.",
         "data": {
           "host": "Hostname/IP",
           "port": "Port",
           "unit_id": "Unit ID",
           "models_enabled": "Read models",
-          "scan_interval": "Scan interval (seconds)"
+          "scan_interval": "Scan interval (seconds)",
+          "max_ac_power_kw": "Peak AC power of the inverter (kW, optional)"
         }
       }
     },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,6 +2,7 @@
 
 from homeassistant.core import HomeAssistant
 
+from custom_components.sunspec.const import CONF_MAX_AC_POWER_KW
 from custom_components.sunspec.sensor import ICON_DC_AMPS
 
 from . import TEST_INVERTER_MM_SENSOR_POWER_ENTITY_ID
@@ -12,7 +13,9 @@ from . import TEST_INVERTER_SENSOR_ENERGY_ENTITY_ID
 from . import TEST_INVERTER_SENSOR_POWER_ENTITY_ID
 from . import TEST_INVERTER_SENSOR_STATE_ENTITY_ID
 from . import TEST_INVERTER_SENSOR_VAR_ID
+from . import create_mock_sunspec_config_entry
 from . import setup_mock_sunspec_config_entry
+from .const import MOCK_CONFIG
 from .const import MOCK_CONFIG_MM
 from .const import MOCK_CONFIG_PREFIX
 
@@ -104,3 +107,40 @@ async def test_sensor_power_mm(hass: HomeAssistant, sunspec_client_mock) -> None
     entity_state = hass.states.get(TEST_INVERTER_MM_SENSOR_POWER_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "9700"
+
+
+async def test_sensor_power_filtered_by_peak_limit(
+    hass: HomeAssistant, sunspec_client_mock
+) -> None:
+    """Power readings above the configured peak should be dropped.
+
+    The mock inverter reports 800 W on the power sensor. With a peak of
+    0.5 kW (= 500 W) the reading is implausible and should be filtered out.
+    """
+    config_entry = create_mock_sunspec_config_entry(
+        hass,
+        data=MOCK_CONFIG,
+        options={CONF_MAX_AC_POWER_KW: 0.5},
+    )
+    await setup_mock_sunspec_config_entry(hass, config_entry=config_entry)
+
+    entity_state = hass.states.get(TEST_INVERTER_SENSOR_POWER_ENTITY_ID)
+    assert entity_state
+    # Filtered values become unknown - the sensor still exists but has no state
+    assert entity_state.state in ("unknown", "unavailable")
+
+
+async def test_sensor_power_passes_through_when_below_limit(
+    hass: HomeAssistant, sunspec_client_mock
+) -> None:
+    """Power readings below the configured peak should pass through unchanged."""
+    config_entry = create_mock_sunspec_config_entry(
+        hass,
+        data=MOCK_CONFIG,
+        options={CONF_MAX_AC_POWER_KW: 10.0},
+    )
+    await setup_mock_sunspec_config_entry(hass, config_entry=config_entry)
+
+    entity_state = hass.states.get(TEST_INVERTER_SENSOR_POWER_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "800"


### PR DESCRIPTION
 ## Motivation

  Some SunSpec inverters report garbage values (MW or TWh range) at dawn
  and dusk when irradiance is too low for a stable reading. These spikes
  poison long-term statistics in Home Assistant and require manual cleanup.

  This adds an opt-in plausibility filter at the integration level so users
  don't need workarounds in templates / utility_meter / sensor.statistics.

  ## What's in the PR

  * New options-flow field **"Peak AC power of the inverter (kW, optional)"**
    in the existing model_options step. Empty disables the filter — no
    behavior change for existing installations.
  * Power-like sensors (`W`, `VA`, `VAr`) above the configured peak are
    dropped (replaced with `None`) and a warning is logged.
  * Energy sensors are checked against a delta limit derived from
    `peak_kw × scan_interval × 2` (safety factor). On a violation the last
    known value is returned, keeping `total_increasing` stats intact —
    reusing the same mechanism as the existing `val == 0` fallback.
  * The very first energy read after a restart with no restored baseline
    is discarded so a potential garbage value never becomes the baseline.
  * Small bug fix in `SunSpecEnergySensor.async_added_to_hass`: the restored
    state was written to the unused `last_known_value` attribute but never
    to `lastKnown` — now both are populated, so the existing `val == 0`
    fallback and the new delta filter both work on the very first poll
    after a restart.

  ## Testing

  * `pytest tests/ --no-cov` → 33 passed locally (HA 2026.2.3, Python 3.13).
  * Two new tests in `tests/test_sensor.py` cover the power filter
    (filtered above limit, passes through below limit).
  * `black` + `flake8` clean.

  ## Notes for the maintainer

  * The default behavior is unchanged — the filter is opt-in via the
    options flow.
  * Happy to split this into smaller commits or move parts behind a
    separate option if you'd prefer.