### PR TITLE
Serialise updates per gateway to support multiple unit IDs on one con…

### DIFF
--- a/custom_components/sunspec/__init__.py
+++ b/custom_components/sunspec/__init__.py
@@ -124,11 +124,32 @@ def get_sunspec_unique_id(
 class SunSpecDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
+    # Per-gateway asyncio lock used to serialise update cycles from multiple
+    # config entries that share the same TCP endpoint (host, port). Several
+    # inverters and Modbus TCP gateways - notably SolarEdge - only accept a
+    # single TCP connection at a time. Without this lock two coordinators
+    # polling different unit IDs behind the same gateway race each other and
+    # produce "connection reset by peer" errors. See issue #317.
+    _GATEWAY_LOCKS: dict = {}
+
+    @classmethod
+    def _get_gateway_lock(cls, host: str, port: int) -> asyncio.Lock:
+        """Return (and lazily create) the asyncio lock for a (host, port)."""
+        key = (host, port)
+        lock = cls._GATEWAY_LOCKS.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            cls._GATEWAY_LOCKS[key] = lock
+        return lock
+
     def __init__(self, hass: HomeAssistant, client: SunSpecApiClient, entry) -> None:
         """Initialize."""
         self.api = client
         self.hass = hass
         self.entry = entry
+        self._gateway_lock = self._get_gateway_lock(
+            entry.data.get(CONF_HOST), entry.data.get(CONF_PORT)
+        )
 
         _LOGGER.debug("Data: %s", entry.data)
         _LOGGER.debug("Options: %s", entry.options)
@@ -162,18 +183,22 @@ class SunSpecDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update data via library."""
         _LOGGER.debug("SunSpec Update data coordinator update")
-        data = {}
-        try:
-            model_ids = self.option_model_filter & set(
-                await self.api.async_get_models()
-            )
-            _LOGGER.debug("SunSpec Update data got models %s", model_ids)
+        # Hold the per-gateway lock for the entire connect/read/close cycle
+        # so that two coordinators sharing the same TCP endpoint never have
+        # an open connection at the same time.
+        async with self._gateway_lock:
+            data = {}
+            try:
+                model_ids = self.option_model_filter & set(
+                    await self.api.async_get_models()
+                )
+                _LOGGER.debug("SunSpec Update data got models %s", model_ids)
 
-            for model_id in model_ids:
-                data[model_id] = await self.api.async_get_data(model_id)
-            self.api.close()
-            return data
-        except Exception as exception:
-            _LOGGER.warning(exception)
-            self.api.reconnect_next()
-            raise UpdateFailed() from exception
+                for model_id in model_ids:
+                    data[model_id] = await self.api.async_get_data(model_id)
+                self.api.close()
+                return data
+            except Exception as exception:
+                _LOGGER.warning(exception)
+                self.api.reconnect_next()
+                raise UpdateFailed() from exception

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -186,6 +186,28 @@ async def test_migrate_entry_from_v1_to_v2_with_both_keys(hass):
     assert "slave_id" not in config_entry.data
 
 
+async def test_gateway_lock_shared_per_host_port(hass):
+    """Coordinators sharing the same TCP endpoint must share one lock.
+
+    See issue #317: this serialises Modbus reads from multiple unit IDs
+    behind one gateway so they don't fight over a single TCP connection.
+    """
+    # Reset class-level state to avoid contamination from other tests.
+    SunSpecDataUpdateCoordinator._GATEWAY_LOCKS.clear()
+
+    a = SunSpecDataUpdateCoordinator._get_gateway_lock("10.0.0.1", 502)
+    b = SunSpecDataUpdateCoordinator._get_gateway_lock("10.0.0.1", 502)
+    c = SunSpecDataUpdateCoordinator._get_gateway_lock("10.0.0.1", 503)
+    d = SunSpecDataUpdateCoordinator._get_gateway_lock("10.0.0.2", 502)
+
+    # Same (host, port) -> same lock instance
+    assert a is b
+    # Different port -> different lock
+    assert a is not c
+    # Different host -> different lock
+    assert a is not d
+
+
 async def test_migrate_entry_version_2_no_migration_needed(hass):
     """Test that version 2 entries don't get migrated."""
     from custom_components.sunspec import async_migrate_entry


### PR DESCRIPTION
Closes #317 (functionally, see "Scope" below).

  ## Motivation

  Several inverters and Modbus TCP gateways (notably SolarEdge) only
  accept a single TCP connection at a time. When two SunSpec config
  entries point at the same `(host, port)` but different unit IDs
  (typical for multiple inverters daisy-chained behind one gateway),
  their `connect / read / close` cycles race each other and produce
  `Socket write error: [Errno 104] Connection reset by peer`. The
  integration is effectively unusable in this topology.

  ## Approach

  Add a class-level `dict[(host, port), asyncio.Lock]` on
  `SunSpecDataUpdateCoordinator` and hold the per-gateway lock for
  the entire update cycle. Two coordinators sharing the same TCP
  endpoint now run their reads sequentially instead of in parallel,
  so exactly one TCP connection is open per gateway at any time.

  * Single-gateway users: zero behavior change (the lock is always
    free).
  * Multi-inverter users: create one config entry per inverter as
    before, they no longer collide.

  ## Why not "multiple unit IDs in one entry"?

  The original issue suggests reworking the wizard to accept a
  comma-separated list of unit IDs. That is a much larger change:
  schema migration v2 to v3, unique IDs derived from `(entry, unit,
  key, model)` instead of `(entry, key, model)` (so existing history
  would break unless carefully backfilled), config-flow rework, and
  docs. I went with the smaller fix because it solves the actual
  symptom users hit (`Connection reset by peer`) without any of
  that risk. A "multi-unit single-entry" PR can come later as pure
  sugar, and would build on top of this lock anyway, since the
  underlying connection-sharing problem still has to be solved.

  ## Testing

  * All 31 existing tests pass unchanged (HA 2026.2.3, Python 3.13).
  * New `test_gateway_lock_shared_per_host_port` in `tests/test_init.py`
    verifies the lock-lookup invariants:
    * Same `(host, port)` returns the same lock instance.
    * Different port leads to a different lock.
    * Different host leads to a different lock.
  * `black` + `flake8` clean.

  ## Scope

  This PR intentionally touches only `__init__.py` and one test
  file. No changes to `config_flow.py`, `sensor.py`, `api.py`,
  translations, or the data schema.