### PR TITLE
Surface SunSpec scan errors as actionable ConnectionError messages

### DIFF
--- a/custom_components/sunspec/api.py
+++ b/custom_components/sunspec/api.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 from homeassistant.core import HomeAssistant
 import sunspec2.modbus.client as modbus_client
+from sunspec2.modbus.client import SunSpecModbusClientError
 from sunspec2.modbus.client import SunSpecModbusClientException
 from sunspec2.modbus.client import SunSpecModbusClientTimeout
 from sunspec2.modbus.modbus import ModbusClientError
@@ -208,10 +209,24 @@ class SunSpecApiClient:
                     connect=False, progress=progress, full_model_read=False, delay=0.5
                 )
                 return client
-            except ModbusClientError:
+            except ModbusClientError as err:
                 raise ConnectionError(
-                    f"Failed to connect to {use_config.host}:{use_config.port} unit id {use_config.unit_id}"
-                )
+                    f"Modbus error while connecting to "
+                    f"{use_config.host}:{use_config.port} unit id "
+                    f"{use_config.unit_id}: {err}"
+                ) from err
+            except SunSpecModbusClientError as err:
+                # Raised by client.scan() when no SunSpec base address is
+                # found, when the device responds without the SunSpec marker,
+                # or on read timeouts during the scan. Without this catch the
+                # original message ("Unknown error", "data time out", etc.)
+                # is hidden behind a generic "Unexpected error" further up
+                # the stack and the user has nothing actionable to report.
+                raise ConnectionError(
+                    f"SunSpec scan failed for "
+                    f"{use_config.host}:{use_config.port} unit id "
+                    f"{use_config.unit_id}: {err}"
+                ) from err
         else:
             _LOGGER.debug("Inverter not ready for Modbus TCP connection")
             raise ConnectionError(f"Inverter not active on {self._host}:{self._port}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 """Tests for SunSpec api."""
 
 import pytest
+from sunspec2.modbus.client import SunSpecModbusClientError
 from sunspec2.modbus.client import SunSpecModbusClientException
 from sunspec2.modbus.client import SunSpecModbusClientTimeout
 from sunspec2.modbus.modbus import ModbusClientError
@@ -116,6 +117,39 @@ async def test_modbus_connect_exception(hass, mocker):
 
     with pytest.raises(ConnectionError):
         api.modbus_connect()
+
+
+async def test_modbus_connect_scan_error_surfaces_message(hass, mocker):
+    """SunSpec scan failures must surface their message in ConnectionError.
+
+    Regression test for issue #346 where client.scan() raised
+    SunSpecModbusClientError but it was not caught by the except block in
+    modbus_connect, leaking through as a generic Exception with message
+    "Unexpected error while connecting" and no actionable details.
+    """
+    mocker.patch(
+        "sunspec2.modbus.client.SunSpecModbusClientDeviceTCP.connect",
+        return_value=None,
+    )
+    mocker.patch(
+        "sunspec2.modbus.client.SunSpecModbusClientDeviceTCP.is_connected",
+        return_value=True,
+    )
+    mocker.patch(
+        "sunspec2.modbus.client.SunSpecModbusClientDeviceTCP.scan",
+        side_effect=SunSpecModbusClientError("data time out"),
+    )
+    mocker.patch(
+        "custom_components.sunspec.SunSpecApiClient.check_port", return_value=True
+    )
+
+    api = SunSpecApiClient(host="test", port=123, unit_id=1, hass=hass)
+
+    with pytest.raises(ConnectionError) as excinfo:
+        api.modbus_connect()
+    # The original sunspec2 message must be preserved so users get something
+    # actionable instead of a generic "Unexpected error".
+    assert "data time out" in str(excinfo.value)
 
 
 async def test_read_model_timeout(hass, mocker):


### PR DESCRIPTION
Refs #346 (improves diagnosability, does not yet fix the underlying
  SMA Sunny Tripower 8.0 SE scan failure but unblocks debugging it).

  ## Problem

  When `client.scan()` in pysunspec2 raises `SunSpecModbusClientError`
  (no SunSpec base address found, device responds without the SunSpec
  marker, read timeouts during the scan), `modbus_connect` did not
  catch it. The existing `except` block only handled `ModbusClientError`,
  which is a different type from a different module and not a parent
  of `SunSpecModbusClientError`.

  The exception leaked through to `_test_connection` in `config_flow.py`,
  where it was caught as a generic `Exception` and logged as
  "Unexpected error while connecting" with no actionable information
  about why the scan failed. Reporters of issue #346 (and likely others)
  see exactly this: a stacktrace that ends at `client.scan()` with no
  underlying cause.

  ## Fix

  Add an explicit `except SunSpecModbusClientError` block in
  `modbus_connect` that wraps the original message in a `ConnectionError`.
  The user-facing log line now reads, for example:

  `Connection failed for host 192.168.1.10:502 unit 3: SunSpec scan failed for 192.168.1.10:502 unit id 3: data time
  out`

  instead of the previous generic "Unexpected error" plus a truncated
  stacktrace. The same treatment is applied to `ModbusClientError` so
  its message is no longer dropped either.

  ## What this does NOT do

  This PR does not attempt to fix the underlying scan failure for SMA,
  SolarEdge, or any other device. We do not have the data to know whether
  the cause is `delay=0.5` being too short, the `check_port()` probe
  upsetting the inverter, a real protocol mismatch, or something else
  entirely. Once issue #346 reporters can post the new actionable error
  message, a targeted fix becomes possible. Spekulative fixes without
  that data are exactly what this PR avoids.

  ## Testing

  * All 31 existing tests pass unchanged (HA 2026.2.3, Python 3.13).
  * New `test_modbus_connect_scan_error_surfaces_message` in
    `tests/test_api.py` mocks `client.scan` with
    `side_effect=SunSpecModbusClientError("data time out")` and asserts
    that the resulting `ConnectionError` message contains
    `"data time out"`.
  * `black` + `flake8` clean.

  ## Scope

  Touches only `api.py` and one test file. No changes to `config_flow.py`,
  the data schema, translations, or anything else. Independent of any
  other open PRs from this branch series.